### PR TITLE
Fix block model in `PaucalBlockStateAndModelProvider`

### DIFF
--- a/Neoforge/src/main/java/at/petrak/paucal/forge/api/datagen/PaucalBlockStateAndModelProvider.java
+++ b/Neoforge/src/main/java/at/petrak/paucal/forge/api/datagen/PaucalBlockStateAndModelProvider.java
@@ -12,7 +12,7 @@ public abstract class PaucalBlockStateAndModelProvider extends BlockStateProvide
   }
 
   protected void blockAndItem(Block block, BlockModelBuilder model) {
-    simpleBlock(block);
+    simpleBlock(block, model);
     simpleBlockItem(block, model);
   }
 


### PR DESCRIPTION
Fix for https://github.com/gamma-delta/PAUCAL/issues/10
Passes BlockModelBuilder to simpleBlock method