### PR TITLE
Fix vector codec encoding (x, y, x)

### DIFF
--- a/Common/src/main/java/at/petrak/paucal/api/PaucalCodecs.java
+++ b/Common/src/main/java/at/petrak/paucal/api/PaucalCodecs.java
@@ -10,7 +10,7 @@ public final class PaucalCodecs {
       (stream, v) -> {
         stream.writeDouble(v.x);
         stream.writeDouble(v.y);
-        stream.writeDouble(v.x);
+        stream.writeDouble(v.z);
       },
       (stream) -> new Vec3(stream.readDouble(), stream.readDouble(), stream.readDouble())
   );


### PR DESCRIPTION
Encodes (x, y, z) instead of (x, y, x) now