### PR TITLE
fix(devenv): shadow relocate Jankson

### DIFF
--- a/Common/build.gradle
+++ b/Common/build.gradle
@@ -1,5 +1,13 @@
+plugins {
+    id "com.github.johnrengelman.shadow" version "8.1.1"
+}
+
 architectury {
     common rootProject.enabled_platforms.split(',')
+}
+
+configurations {
+    shadowBundle
 }
 
 pkSubproj {
@@ -15,4 +23,18 @@ dependencies {
 
     // Architectury API. This is optional, and you can comment it out if you don't need it.
     modImplementation "dev.architectury:architectury:$rootProject.architectury_api_version"
+    compileOnly "blue.endless:jankson:$rootProject.jankson_version"
+    shadowBundle "blue.endless:jankson:$rootProject.jankson_version"
+}
+
+shadowJar {
+    relocate "blue.endless.jankson", "${rootProject.maven_group}.paucal.shadowed.blue.endless.jankson"
+
+    configurations = [project.configurations.shadowBundle]
+    archiveClassifier = "shadow"
+}
+
+remapJar {
+    input.set(shadowJar.archiveFile)
+    dependsOn(shadowJar)
 }

--- a/Fabric/build.gradle
+++ b/Fabric/build.gradle
@@ -29,6 +29,7 @@ configurations {
         canBeResolved = true
         canBeConsumed = false
     }
+    shadowCommon
     compileClasspath.extendsFrom common
     runtimeClasspath.extendsFrom common
     developmentFabric.extendsFrom common
@@ -53,7 +54,8 @@ dependencies {
     modImplementation "me.shedaniel.cloth:cloth-config:$project.cloth_cfg_version"
     modImplementation "com.terraformersmc:modmenu:$project.mod_menu_version"
 
-    include "blue.endless:jankson:$rootProject.jankson_version"
+    implementation "blue.endless:jankson:$rootProject.jankson_version"
+    shadowBundle "blue.endless:jankson:$rootProject.jankson_version"
 
     common(project(path: ':Common', configuration: 'namedElements')) { transitive false }
     shadowBundle project(path: ':Common', configuration: 'transformProductionFabric')
@@ -73,10 +75,13 @@ processResources {
 }
 
 shadowJar {
+    relocate "blue.endless.jankson", "${rootProject.maven_group}.paucal.shadowed.blue.endless.jankson"
+
     configurations = [project.configurations.shadowBundle]
     archiveClassifier = 'dev-shadow'
 }
 
 remapJar {
     input.set shadowJar.archiveFile
+    dependsOn(shadowJar)
 }

--- a/Fabric/build.gradle
+++ b/Fabric/build.gradle
@@ -29,7 +29,6 @@ configurations {
         canBeResolved = true
         canBeConsumed = false
     }
-    shadowCommon
     compileClasspath.extendsFrom common
     runtimeClasspath.extendsFrom common
     developmentFabric.extendsFrom common

--- a/Neoforge/build.gradle
+++ b/Neoforge/build.gradle
@@ -23,6 +23,7 @@ configurations {
         canBeResolved = true
         canBeConsumed = false
     }
+    shadowCommon
     compileClasspath.extendsFrom common
     runtimeClasspath.extendsFrom common
     developmentNeoForge.extendsFrom common
@@ -51,8 +52,8 @@ dependencies {
     common(project(path: ':Common', configuration: 'namedElements')) { transitive false }
     shadowBundle(project(path: ':Common', configuration: 'transformProductionNeoForge')) { transitive false }
 
-    include "blue.endless:jankson:$rootProject.jankson_version"
-    forgeRuntimeLibrary "blue.endless:jankson:$rootProject.jankson_version"
+    modLocalRuntime "blue.endless:jankson:$rootProject.jankson_version"
+    forgeRuntimeLibrary(shadowBundle("blue.endless:jankson:$rootProject.jankson_version"))
 }
 
 def generatedResources = project(":Common").file("src/generated/resources")
@@ -82,10 +83,13 @@ processResources {
 }
 
 shadowJar {
+    relocate "blue.endless.jankson", "${rootProject.maven_group}.paucal.shadowed.blue.endless.jankson"
+
     configurations = [project.configurations.shadowBundle]
     archiveClassifier = 'dev-shadow'
 }
 
 remapJar {
     input.set shadowJar.archiveFile
+    dependsOn(shadowJar)
 }

--- a/Neoforge/build.gradle
+++ b/Neoforge/build.gradle
@@ -23,7 +23,6 @@ configurations {
         canBeResolved = true
         canBeConsumed = false
     }
-    shadowCommon
     compileClasspath.extendsFrom common
     runtimeClasspath.extendsFrom common
     developmentNeoForge.extendsFrom common

--- a/build.gradle
+++ b/build.gradle
@@ -60,8 +60,6 @@ subprojects {
         minecraft "net.minecraft:minecraft:$rootProject.minecraft_version"
         mappings loom.officialMojangMappings()
 
-        // Make this implementation accessible from all projects
-        implementation "blue.endless:jankson:$rootProject.jankson_version"
     }
 
     pkJson5 {


### PR DESCRIPTION
Allows Jankson to be used by PAUCAL without the version being changed by other mods.
Fixes runClient tasks failing due to NoClass/MethodDefExceptions related to Jankson being forced to older versions than desired.